### PR TITLE
[auto-merge] bot-auto-merge-branch-24.04 to branch-24.06 [skip ci] [bot]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -43,7 +43,15 @@ jobs:
           git fetch origin ${HEAD} ${BASE}
           git checkout -b ${INTERMEDIATE_HEAD} origin/${HEAD}
           git checkout origin/${BASE} -- ${FILES_USE_BASE}
+          git --version
+          git status
+          echo '1'
+          git status --porcelain=v1
+          echo '2'
           git status --porcelain=v1 --untracked=no
+          echo '3'
+          git status --porcelain=v1 --untracked-files=no
+          echo '4'
           [ ! -z "$(git status --porcelain=v1 --untracked=no)" ] && \
             git commit -s -am "Auto-merge use ${BASE} versions"
           git log --oneline -n 5

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -43,8 +43,10 @@ jobs:
           git fetch origin ${HEAD} ${BASE}
           git checkout -b ${INTERMEDIATE_HEAD} origin/${HEAD}
           git checkout origin/${BASE} -- ${FILES_USE_BASE}
+          git status --porcelain=v1 --untracked=no
           [ ! -z "$(git status --porcelain=v1 --untracked=no)" ] && \
             git commit -s -am "Auto-merge use ${BASE} versions"
+          git log --oneline -n 5
           git push origin ${INTERMEDIATE_HEAD} -f
         env:
           INTERMEDIATE_HEAD: bot-auto-merge-${{ env.HEAD }}


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-24.04` to create a PR keeping `branch-24.06` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.